### PR TITLE
fixed smtp return code

### DIFF
--- a/lib/mini-smtp-server/mini-smtp-server.rb
+++ b/lib/mini-smtp-server/mini-smtp-server.rb
@@ -31,16 +31,16 @@ class MiniSmtpServer < GServer
     # Handle specific messages from the client
     case line
     when (/^(HELO|EHLO)/)
-      return "220 go on...\r\n"
+      return "250 go on...\r\n"
     when (/^QUIT/)
       Thread.current[:connection_active] = false
       return ""
     when (/^MAIL FROM\:/)
       Thread.current[:message][:from] = line.gsub(/^MAIL FROM\:/, '').strip
-      return "220 OK\r\n"
+      return "250 OK\r\n"
     when (/^RCPT TO\:/)
       Thread.current[:message][:to] = line.gsub(/^RCPT TO\:/, '').strip
-      return "220 OK\r\n"
+      return "250 OK\r\n"
     when (/^DATA/)
       Thread.current[:data_mode] = true
       return "354 Enter message, ending with \".\" on a line by itself\r\n"
@@ -52,7 +52,7 @@ class MiniSmtpServer < GServer
     if((Thread.current[:data_mode]) && (line.chomp =~ /^\.$/))
       Thread.current[:message][:data] += line
       Thread.current[:data_mode] = false
-      return "220 OK\r\n"
+      return "250 OK\r\n"
     end
     
     # If we are in date mode then we need to add


### PR DESCRIPTION
I send a mail to localhost:2525 using Thunderbird, then Thunderbird send a "EHLO" command for all time.

mini-smtp-server always return 220 code, but looks like 250 is correct.
http://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol#SMTP_transport_example

This pull request solves that issue.
