### PR TITLE
Adding new RDoc tasks requiring method

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,10 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+begin
+  require 'rdoc/task'
+rescue LoadError
+  require 'rake/rdoctask'
+end
 
 desc 'Default: run unit tests.'
 task :default => :test


### PR DESCRIPTION
It requires via 'rdoc/task', and if that's fail, then falls back the old 'rake/rdoctask'
