### PR TITLE
Support multiple email recipients and multiple emails in a single session

### DIFF
--- a/lib/mini-smtp-server/mini-smtp-server.rb
+++ b/lib/mini-smtp-server/mini-smtp-server.rb
@@ -8,7 +8,7 @@ class MiniSmtpServer < GServer
   
   def serve(io)
     Thread.current[:data_mode] = false
-    Thread.current[:message] = {:data => "", :to => []}
+    reset_message
     Thread.current[:connection_active] = true
     io.print "220 hello\r\n"
     loop do
@@ -23,8 +23,6 @@ class MiniSmtpServer < GServer
     end
     io.print "221 bye\r\n"
     io.close
-    Thread.current[:message][:data].gsub!(/\r\n\Z/, '').gsub!(/\.\Z/, '')
-    new_message_event(Thread.current[:message])
   end
 
   def process_line(line)
@@ -52,6 +50,10 @@ class MiniSmtpServer < GServer
     if((Thread.current[:data_mode]) && (line.chomp =~ /^\.$/))
       Thread.current[:message][:data] += line
       Thread.current[:data_mode] = false
+
+      Thread.current[:message][:data].gsub!(/\r\n\Z/, '').gsub!(/\.\Z/, '')
+      new_message_event(Thread.current[:message])
+      reset_message
       return "250 OK\r\n"
     end
     
@@ -68,5 +70,11 @@ class MiniSmtpServer < GServer
   end
   
   def new_message_event(message_hash)
+  end
+
+  private
+
+  def reset_message
+    Thread.current[:message] = {:data => "", :to => []}
   end
 end

--- a/test/unit/mini_smtp_server_test.rb
+++ b/test/unit/mini_smtp_server_test.rb
@@ -56,6 +56,18 @@ class MiniSmtpServerTest < Test::Unit::TestCase
     send_mail($example_mail, "smtp@test.com", ["some1@test.com", "some2@test.com"])
     assert_equal ["<some1@test.com>", "<some2@test.com>"], $messages.first[:to]
   end
+
+  test "should support multiple emails in a single smtp session" do
+      Net::SMTP.start('127.0.0.1', 2525) do |smtp|
+        smtp.send_message("Some email data", "smtp@test.com", "some1@test.com")
+        smtp.send_message("Some more email data", "smtp2@test.com", "some2@test.com")
+      end
+      sleep 0.01
+      assert_equal 2, $messages.count
+
+      assert_equal({:data => "Some email data\r\n", :from => "<smtp@test.com>", :to => ["<some1@test.com>"]}, $messages[0])
+      assert_equal({:data => "Some more email data\r\n", :from => "<smtp2@test.com>", :to => ["<some2@test.com>"]}, $messages[1])
+  end
   
   test "should store email body in message hash" do
     assert_difference("$messages.length") do


### PR DESCRIPTION
When there are multiple recipients on an email `RCPT TO` gets sent multiple times. See section 4.1.1.3 of http://www.ietf.org/rfc/rfc2821.txt.

Support this by returning an array for `:to`

This change is not backwards compatible when there is a single recipient. I figured it would be more consistent to always return an array. I'm happy to change this if you don't think that is the best way to handle this!

The second commit also adds support for multiple emails in a single session (which some clients may expect). The current behaviour would be to silently throw away every but the last email in a session but weirdly to concatenate the data sections of the email.

The commit makes a very small change to record the message after the `DATA` block has finished and reset the message.
