### PR TITLE
Fixed the ehlo syntax to match lower cased ehlo command

### DIFF
--- a/lib/mini-smtp-server/mini-smtp-server.rb
+++ b/lib/mini-smtp-server/mini-smtp-server.rb
@@ -28,7 +28,7 @@ class MiniSmtpServer < GServer
   def process_line(line)
     # Handle specific messages from the client
     case line
-    when (/^(HELO|EHLO)/)
+    when (/^(HELO|EHLO)/i)
       return "250 #{Socket.gethostname} go on...\r\n"
     when (/^QUIT/)
       Thread.current[:connection_active] = false


### PR DESCRIPTION
I was testing the SMTP service and found out that the RFC doesn't require the EHLO and HELO to be case sensitive.